### PR TITLE
supply HcalSiPMParameters_2017_v4.0_mc for testing zero HO dark current

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -36,9 +36,9 @@ autoCond = {
     # GlobalTag for Run2 HLT for HI: it points to the online GT
     'run2_hlt_hi'       :   '81X_dataRun2_HLTHI_frozen_v3',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017 (and 0,0,0-centred beamspot)
-    'phase1_2017_design' :  '81X_upgrade2017_design_IdealBS_v1',
+    'phase1_2017_design' :  '81X_upgrade2017_design_Candidate_2016_10_27_16_45_28',
     # GlobalTag for MC production with realistic conditions for Phase1 2017 detector
-    'phase1_2017_realistic': '81X_upgrade2017_realistic_v17',
+    'phase1_2017_realistic': '81X_upgrade2017_realistic_Candidate_2016_10_27_16_38_18',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design'   : 'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with realistic conditions for Phase2 2023


### PR DESCRIPTION
Hi @kpedro88 this will supply your PR https://github.com/cms-sw/cmssw/pull/16315 with the needed payload.
Since `autoCond` has changed in the meanwhile already twice, you'll need to rebase after merge.
I am not providing full fledged GT (the following version number is already taken by https://github.com/cms-sw/cmssw/pull/16301) but only candidates. I will need to edit the tags in the already done GTs in the geometry PRs (sigh...)

Here is the diff with the latest Global Tags:

```
conddb diff 81X_upgrade2017_realistic_Candidate_2016_10_27_16_38_18 81X_upgrade2017_realistic_v19
---------------------  -----  ----------------------------------------------------------------  --------------------------------------  
HcalSiPMParametersRcd  -      HcalSiPMParameters_2017_v4.0_mc                                   HcalSiPMParameters_2017_v2.0_mc  
```

```
$ conddb diff 81X_upgrade2017_design_Candidate_2016_10_27_16_45_28 81X_upgrade2017_design_IdealBS_v3
---------------------  -----  -------------------------------------------------------------  ------------------------------------------  
HcalSiPMParametersRcd  -      HcalSiPMParameters_2017_v4.0_mc                                HcalSiPMParameters_2017_v2.0_mc
```
