### PR TITLE
use old thresholds when running collapsed 2018

### DIFF
--- a/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
+++ b/RecoLocalCalo/CaloTowersCreator/python/calotowermaker_cfi.py
@@ -161,4 +161,8 @@ from Configuration.ProcessModifiers.run2_HECollapse_2018_cff import run2_HEColla
 run2_HECollapse_2018.toModify(calotowermaker,
     HcalPhase = cms.int32(0),
     HcalCollapsed = cms.bool(True),
+    HESThreshold1 = cms.double(0.8),
+    HESThreshold  = cms.double(0.8),
+    HEDThreshold1 = cms.double(0.8),
+    HEDThreshold  = cms.double(0.8)
 )


### PR DESCRIPTION
refers to comment:
https://github.com/cms-sw/cmssw/pull/21842#discussion_r161987013